### PR TITLE
Feature issue #5 create search form

### DIFF
--- a/includes/js/index.js
+++ b/includes/js/index.js
@@ -1,0 +1,62 @@
+//Enable make and model select elements
+const makeModelYearForm = document.getElementById("make-model-year-form");
+const yearDropdown = document.getElementById("car-year");
+const makeDropdown = document.getElementById("make");
+const modelDropdown = document.getElementById("model");
+
+//Performs following actions if the make/model/year form is present on page
+if ( makeModelYearForm ) {
+
+    // Enables model selection field on change and performs REST API call to retrieve model selection options
+    makeDropdown.addEventListener("change", (event) => {
+        modelDropdown.selectedIndex = 0;
+        yearDropdown.setAttribute("disabled", "");
+        yearDropdown.selectedIndex = 0;
+
+        if(makeDropdown.selectedIndex === 0) {
+            modelDropdown.setAttribute("disabled", "");
+        } else{
+            modelDropdown.removeAttribute("disabled");
+            let makeValue = makeDropdown.value;
+            let modelOptions = '<option value="">Model</option>'
+            modelDropdown.innerHTML = modelOptions;
+            fetch('/wp-json/woommy/v1/models?selected_make=' + makeValue + `&timestamp=${Date.now()}`)
+            .then(response => response.json())
+            .then(models => {
+                models.forEach(model => {
+                    modelOptions += '<option value="' + model.slug + '">' + model.name + '</option>'
+                });
+                modelDropdown.innerHTML = modelOptions;
+            })
+            .catch(error => {
+                console.error('Error fetching data:', error);
+            });
+        }
+    });
+
+    // Enables year selection field on change and performs REST API call to retrieve year selection options
+    modelDropdown.addEventListener("change", (event) => {        
+        
+        yearDropdown.selectedIndex = 0;
+
+        if (modelDropdown.selectedIndex === 0) {
+            yearDropdown.setAttribute("disabled", "");
+        } else {
+            yearDropdown.removeAttribute("disabled");
+            let modelValue = modelDropdown.value;
+            let yearOptions = '<option value="">Year</option>'
+            yearDropdown.innerHTML = yearOptions;
+            fetch('/wp-json/woommy/v1/years?selected_model=' + modelValue + `&timestamp=${Date.now()}`)
+            .then(response => response.json())
+            .then(years => {
+                years.forEach( year => {
+                    yearOptions += '<option value="' + year.slug + '">' + year.name + '</option>'
+                });
+                yearDropdown.innerHTML = yearOptions;
+            })
+            .catch(error => {
+                console.error('Error fetching data:', error);
+            });
+        }
+    });
+}

--- a/woo-mmy.php
+++ b/woo-mmy.php
@@ -161,3 +161,65 @@ function save_field( $post_id, $post ) {
 }
 
 add_action( 'woocommerce_process_product_meta', 'save_field', 10, 2 );
+
+/**
+ * Custom shortcode to add year, make, model search form
+ */
+function make_model_year_shortcode() {
+	
+	return '
+		<form id="make-model-year-form" action="' . esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ) .  '" method="get">
+			<div class="container">
+				<select id="make" name="make" required>
+					<option value="">Make</option>'. get_make_options() .
+				'</select>
+				<select id="model" name="model" required>
+					<option value="">Model</option>
+				</select>
+				<select id="car-year" name="car-year" required>
+					<option value="">Year</option>
+				</select>
+			</div>
+			<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+				<div class="wp-block-button"><button class="wp-block-button__link wp-element-button" type="submit">Search</button></div>
+			</div>
+		</form>
+	';
+}
+
+add_shortcode('make-model-year-form', 'make_model_year_shortcode');
+
+function get_make_options() {
+	$terms = get_terms( array( 
+		'taxonomy' => 'woommy-car-details',
+	) );
+
+	//iterate over the custom taxonomy terms array and build an array of make names that have child models with the specified year
+	$makes = array();
+	$make_options = '';
+	foreach ( $terms as $term ) {
+		if ( 0 === $term->parent ) {
+			$make = array(
+				'slug' => $term->slug,
+				'name' => $term->name
+			);
+			if ( $make && ! in_array( $make["slug"], array_column( $makes, "slug" ) ) ) {
+				array_push( $makes, $make );
+			}
+		}
+		
+	}
+
+	foreach( $makes as $make ) {
+
+		$make_is_selected = '';
+		 
+		if( is_shop() && isset( $_GET['make'] ) && $make["slug"] === $_GET['make'] ) {
+			$make_is_selected = 'selected'; 
+		}
+		
+		$make_options .= '<option value="' . $make["slug"] . '" ' . $make_is_selected . '>' . $make["name"] . '</option>';
+	}
+
+	return $make_options;
+ }

--- a/woo-mmy.php
+++ b/woo-mmy.php
@@ -173,12 +173,12 @@ function make_model_year_shortcode() {
 				<select id="make" name="make" required>
 					<option value="">Make</option>'. get_make_options() .
 				'</select>
-				<select id="model" name="model" required>
-					<option value="">Model</option>
-				</select>
-				<select id="car-year" name="car-year" required>
-					<option value="">Year</option>
-				</select>
+				<select id="model" name="model" ' . $model_options['disabled'] . ' required>
+					<option value="">Model</option>' . $model_options['options'] . 
+				'</select>
+				<select id="car-year" name="car-year" ' . $year_options['disabled'] . ' required>
+					<option value="">Year</option>' . $year_options['options'] .
+				'</select>
 			</div>
 			<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
 				<div class="wp-block-button"><button class="wp-block-button__link wp-element-button" type="submit">Search</button></div>
@@ -223,3 +223,140 @@ function get_make_options() {
 
 	return $make_options;
  }
+
+ function get_models( $selected_make ) {
+	$terms = get_terms( array( 
+		'taxonomy' => 'woommy-car-details',
+	) );
+
+	//iterate over the custom taxonomy terms array and build an array of model names that have parents of the specified make
+	$models = array();
+	$make_term = get_term_by( 'slug', sanitize_title($selected_make), 'woommy-car-details' );
+	$make_id = $make_term->term_id;
+
+	foreach ( $terms as $term ) {
+		if ( $term->parent === $make_id ) {
+			$model = array(
+				"slug" => $term->slug,
+				"name" => $term->name
+			);
+
+			if ( ! in_array( $model["slug"], array_column( $models, "slug" ) ) ) {
+				array_push( $models, $model );
+			}
+		}
+	}
+
+	return $models;
+}
+
+function get_model_options() {
+	
+	$model_options = array(
+		'disabled' => 'disabled',
+		'options' => ''
+	);
+	
+	if( is_shop() && isset( $_GET['make'] ) && isset( $_GET['model'] ) && isset( $_GET['car-year']) ) {
+
+		$model_options['disabled'] = '';
+
+		$models = get_models( $_GET['make'] );
+
+		foreach( $models as $model ) {
+
+			$model_is_selected = '';
+
+			if( $model["slug"] === $_GET['model'] ) {
+				$model_is_selected = 'selected';
+			}
+			
+			$model_options['options'] .= '<option value="' . $model["slug"] . '" ' . $model_is_selected . '>' . $model["name"] . '</option>';
+		}
+	} 
+
+	return $model_options;
+}
+
+function get_years( $selected_model ) {
+	$terms = get_terms( array( 
+		'taxonomy' => 'woommy-car-details',
+	) );
+
+	//iterate over the custom taxonomy terms array and build an array of year slugs and names that have the specified parent model
+	$selected_model_id = get_term_by('slug', sanitize_title( $selected_model ), 'woommy-car-details')->term_id;
+	$years = array();
+
+	foreach ( $terms as $term ) {
+		if ( $term->parent === $selected_model_id ) {
+			$year = array(
+				"slug" => $term->slug,
+				"name" => $term->name
+			);
+			
+			if ( $year && ! in_array( $year["slug"], array_column( $years, "slug" ) ) ) {
+				array_push( $years, $year );
+			}
+		}	
+	}
+
+	return $years;
+}
+
+function get_year_options() {
+	
+	$year_options = array(
+		'disabled' => 'disabled',
+		'options' => ''
+	);
+	
+	if( is_shop() && isset( $_GET['make'] ) && isset( $_GET['model'] ) && isset( $_GET['car-year']) ) {
+
+		$year_options['disabled'] = '';
+
+		$years = get_years( $_GET['model'] );
+
+		foreach( $years as $year ) {
+
+			$year_is_selected = '';
+
+			if( $year["slug"] === $_GET['car-year'] ) {
+				$year_is_selected = 'selected';
+			}
+			
+			$year_options['options'] .= '<option value="' . $year["slug"] . '" ' . $year_is_selected . '>' . $year["name"] . '</option>';
+		}
+	} 
+
+	return $year_options;
+}
+
+//Custom enpoint to grab models from the custom taxonomy based on selected make
+function custom_model_endpoint( WP_REST_Request $request ) {
+	$selected_make = $request->get_param( 'selected_make' );
+
+	$models = get_models( $selected_make );
+
+	return rest_ensure_response( $models );
+}
+
+//Custom enpoint to grab years from the custom taxonomy based on selected model
+function custom_year_endpoint( WP_REST_Request $request ) {
+	$selected_model = $request->get_param('selected_model');
+
+	$years = get_years( $selected_model );
+	return rest_ensure_response( $years );
+}
+
+add_action( 'rest_api_init', function () {
+	register_rest_route( 'woommy/v1', '/models/', array(
+		'methods' => 'GET',
+		'callback' => 'custom_model_endpoint',
+		'permission_callback' => '__return_true',
+	) );
+	register_rest_route( 'woommy/v1', '/years/', array(
+	  'methods' => 'GET',
+	  'callback' => 'custom_year_endpoint',
+	  'permission_callback' => '__return_true',
+	) );
+} );


### PR DESCRIPTION
## What?

#5 

## Why?

The form needs to be populated with the appropriate taxonomy terms, and the model and year options should be dependent on the make and model selected (respectively). 

## Testing

![image](https://github.com/user-attachments/assets/a86eceeb-b3a8-48b5-88d5-19077b2455fe)
The form select elements display as expected.

![responsive-mmy-form](https://github.com/user-attachments/assets/bc68c8f0-32eb-46eb-b650-b352559b2fbf)
The form is responsive, and each subsequent select field is populated with options according to the hierarchical make/model/year taxonomy.

![image](https://github.com/user-attachments/assets/a31d0e57-c891-499d-9658-4f765416bf49)
The user's selections persist and populate the MMY form on the shop page based on the MMY slugs in the query string.
