### PR TITLE
initializes model options and year options

### DIFF
--- a/woo-mmy.php
+++ b/woo-mmy.php
@@ -166,6 +166,8 @@ add_action( 'woocommerce_process_product_meta', 'save_field', 10, 2 );
  * Custom shortcode to add year, make, model search form
  */
 function make_model_year_shortcode() {
+	$model_options = get_model_options();
+	$year_options = get_year_options();
 	
 	return '
 		<form id="make-model-year-form" action="' . esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ) .  '" method="get">


### PR DESCRIPTION
## What?

Prior to an input in the make select field, the model and year fields should be disabled with no options. The functions  `get_model_options()` and `get_year_options()` return associative arrays to enable/disable and add options to the select elements. If there is no relevant information in the query string to populate those fields (i.e., on the home page before the user has made any selections), the same functions should disable the make and model select fields and .

## Why?
For this to work the `$model_options` and `$year_options` variables need to be given the return value of the `get_model_options()` and `get_year_options()` functions before the variables are used to populate the form.