### PR TITLE
adds basic default styles to MMY form

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,54 @@
+form#make-model-year-form {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-flex-wrap: wrap;
+		-ms-flex-wrap: wrap;
+			flex-wrap: wrap;
+	-webkit-box-pack: center;
+	-webkit-justify-content: center;
+		-ms-flex-pack: center;
+			justify-content: center;
+	width: 100%;
+	gap: 1em;
+  }
+  
+  form#make-model-year-form div.container {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-flex-wrap: wrap;
+		-ms-flex-wrap: wrap;
+			flex-wrap: wrap;
+	-webkit-flex-basis: 80%;
+		-ms-flex-preferred-size: 80%;
+			flex-basis: 80%;
+	-webkit-box-flex: 1;
+	-webkit-flex-grow: 1;
+		-ms-flex-positive: 1;
+			flex-grow: 1;
+	gap: 1em;
+	padding: 0 1em;
+  }
+
+  form#make-model-year-form div.container select {
+	-webkit-box-flex: 1;
+	-webkit-flex-grow: 1;
+		-ms-flex-positive: 1;
+			flex-grow: 1;
+	-webkit-flex-basis: 12em;
+		-ms-flex-preferred-size: 12em;
+			flex-basis: 12em;
+	margin-bottom: 0;
+	padding: 0.25em;
+  }
+
+  form#make-model-year-form div.container br {
+	display: none;
+  }
+
+  form#make-model-year-form .wp-block-buttons {
+	gap: unset;
+  }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -31,3 +31,18 @@ function add_custom_scripts() {
 
 }
 add_action( 'wp_enqueue_scripts', 'add_custom_scripts' );
+
+function add_custom_styles() {
+
+	// register the style
+	wp_register_style( 
+		'rps-main-css',
+		woommy_plugin_url('/assets/css/styles.css')
+	);
+
+	//enqueue the style
+	wp_enqueue_style( 'rps-main-css' );
+
+}
+add_action( 'wp_enqueue_scripts', 'add_custom_styles' );
+


### PR DESCRIPTION
## What?

See #9. 
Basic styles were adapted from an existing custom theme and enqueued via the wp_enqueue_scripts action hook.
Additional custom styles may be used in a theme to override these styles or to further personalize the form.

## Why?

The un-styled form was very ugly.

![image](https://github.com/user-attachments/assets/2823eb65-f7c3-4cd7-a60f-6d643977c1ef)
form before adding styles

## Testing

![image](https://github.com/user-attachments/assets/b0fd63bd-595d-4106-9f2a-aa858f86fb99)
Styled form on home page

