### PR TITLE
renames styles in enqueue scripts callback

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -36,12 +36,12 @@ function add_custom_styles() {
 
 	// register the style
 	wp_register_style( 
-		'rps-main-css',
+		'woommy-css',
 		woommy_plugin_url('/assets/css/styles.css')
 	);
 
 	//enqueue the style
-	wp_enqueue_style( 'rps-main-css' );
+	wp_enqueue_style( 'woommy-css' );
 
 }
 add_action( 'wp_enqueue_scripts', 'add_custom_styles' );


### PR DESCRIPTION
## What?

The naming in the enqueue scripts callback made reference to the name of the plugin from which the styles were adapted.

## Why?

The styles are meant to be generic and related to the plugin rather than any specific theme.