### PR TITLE
Feature issue #14 taxonomy query

### DIFF
--- a/includes/taxonomy-query.php
+++ b/includes/taxonomy-query.php
@@ -1,1 +1,20 @@
 <?php
+
+/**
+ * Apply filers submitted by the rps-mmy form on the shop page
+ */
+ 	
+ function add_woommy_tax_query( $query ) {
+	if ( is_shop() && isset( $_GET['make'] ) && isset( $_GET['model'] ) && isset( $_GET['car-year']) ) {
+		//modify the query parameters
+		$query->set( 'tax_query', array(
+			array(
+				'taxonomy' => 'woommy-car-details',
+				'field'    => 'slug',
+				'terms'    => $_GET['car-year'],
+			),
+		) );
+	}
+}
+
+add_action( 'woocommerce_product_query', 'add_woommy_tax_query' );

--- a/includes/taxonomy-query.php
+++ b/includes/taxonomy-query.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Apply filers submitted by the rps-mmy form on the shop page
+ * Apply filers submitted by the woommy form on the shop page
  */
  	
  function add_woommy_tax_query( $query ) {


### PR DESCRIPTION
## What?

#14 

## Why?

User selections in the MMY form need a way to filter the products displayed on the shop page. This code achieves that by hooking into the ```woocommerce_product_query``` action and using the GET parameters from the MMY form submission to filter the products.

## Testing

**Before implementation:**
![image](https://github.com/user-attachments/assets/dd0539f8-32f0-4fe1-b89b-76ba64fa1baa)
Before adding the product query hook, all items are displayed on the shop page regardless of MMY user selection. In this example only three test products have been added to the database: two Chevelle product and a Cutlas product.

**After implementation:**
![custom_taxonomy_query_test](https://github.com/user-attachments/assets/74489647-bf31-4a8e-a2b5-729821298ddd)
After implementation only products matching the selected make, model, and year appear

