### PR TITLE
Bugfix issue #25 capitalize make model term names

### DIFF
--- a/includes/product-options.php
+++ b/includes/product-options.php
@@ -45,8 +45,8 @@ function save_field( $post_id, $post ) {
 
 		$car_array = explode( ',', $car );
 		
-		$make  = array_key_exists( 0, $car_array ) ? trim( $car_array[0] ) : '';
-		$model = array_key_exists( 1, $car_array ) ? trim( $car_array[1] ) : '';
+		$make  = array_key_exists( 0, $car_array ) ? ucwords(trim( $car_array[0] )) : '';
+		$model = array_key_exists( 1, $car_array ) ? ucwords(trim( $car_array[1] )) : '';
 		$years = array_key_exists( 2, $car_array ) ? trim( $car_array[2] ) : '';
 
 		if ( '' === $make ) {

--- a/woo-mmy.php
+++ b/woo-mmy.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name:       WooMMY
  * Description:       Search products by Make, Model, and Year by using custom taxonomies to categorize them.
- * Version:           0.2.0
+ * Version:           0.3.0
  * Author:            Andrew Smith
  * Author URI:        https://andycodes.net/
  * License:           GPL v3 or later
@@ -14,7 +14,7 @@
 	exit; // Exit if accessed directly
 }
 
-define( 'WOOMMY_VERSION', '0.2.0' );
+define( 'WOOMMY_VERSION', '0.3.0' );
 
 define( 'WOOMMY_PLUGIN' , __FILE__ );
 


### PR DESCRIPTION
## What?

#25 

## Why?

Capitalizing the makes and models before adding them as taxonomy terms will force consistency in how the make and model options are output on the front end.

## Testing

Lower case inputs for make and model in the MMY product data field now results in the term name being capitalized, which means the options populating the select fields will also be capitalized.

Product data input:
![image](https://github.com/user-attachments/assets/ee2a2478-3854-467b-ac4c-0441d2177f37)

Data in the wp_terms table (note term name is capitalized while slug is still transformed to lowercase by built in WP functions):
![image](https://github.com/user-attachments/assets/be5f47db-365e-4b86-a2b5-b9b9e85927ca)

Select field options:
![image](https://github.com/user-attachments/assets/8f64ad7d-c4b8-4c06-ad22-b071321b52fe)